### PR TITLE
Fix UC work allowance, Class 2 NI abolition, 2023/24 NI rate

### DIFF
--- a/parameters/2023_24.yaml
+++ b/parameters/2023_24.yaml
@@ -26,10 +26,15 @@ income_tax:
 national_insurance:
   primary_threshold_annual: 12570.0
   upper_earnings_limit_annual: 50270.0
-  main_rate: 0.12    # 12% before Jan 2024 cut (10% from Jan, but 12% for full FY avg)
+  # NI (Reduction in Rates) Act 2023: main rate cut from 12% to 10% from 6 Jan 2024.
+  # Blended annual rate: (12% × 9/12) + (10% × 3/12) = 11.5%
+  main_rate: 0.115
   additional_rate: 0.02
   secondary_threshold_annual: 9100.0
   employer_rate: 0.138
+  # Class 2 (self-employed flat rate): £3.45/week (SSCBA 1992 s.11, SI 2023/319)
+  class2_flat_rate_weekly: 3.45
+  class2_small_profits_threshold: 6725.0
   class4_lower_profits_limit: 12570.0
   class4_upper_profits_limit: 50270.0
   class4_main_rate: 0.09

--- a/parameters/2024_25.yaml
+++ b/parameters/2024_25.yaml
@@ -35,6 +35,9 @@ national_insurance:
   class4_upper_profits_limit: 50270.0
   class4_main_rate: 0.06  # Reduced from 8% to 6% from 6 Apr 2024
   class4_additional_rate: 0.02
+  # Class 2 abolished from 6 April 2024 (National Insurance Contributions Act 2024)
+  class2_flat_rate_weekly: 0.0
+  class2_small_profits_threshold: 0.0
 
 universal_credit:
   # SI 2024/242 (Up-rating Order 2024), amending UC Regs 2013 reg.36

--- a/parameters/2025_26.yaml
+++ b/parameters/2025_26.yaml
@@ -47,10 +47,9 @@ national_insurance:
   # (Reduction in Rates) Act 2024 c.1)
   main_rate: 0.08
   additional_rate: 0.02
-  # Class 2 (self-employed flat rate): SSCBA 1992 s.11
-  # £3.45/week for profits above small profits threshold £6,725
-  class2_flat_rate_weekly: 3.45
-  class2_small_profits_threshold: 6725.0
+  # Class 2 abolished from 6 April 2024 (National Insurance Contributions Act 2024)
+  class2_flat_rate_weekly: 0.0
+  class2_small_profits_threshold: 0.0
   # Class 1 employer (secondary): SSCBA 1992 s.9; SI 2025/288
   # Secondary threshold reduced to £5,000/year from April 2025 (Autumn Budget 2024)
   # Employer rate increased to 15% from April 2025

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -144,8 +144,9 @@ pub struct NationalInsuranceParams {
 
 fn default_secondary_threshold() -> f64 { 5000.0 }
 fn default_employer_rate() -> f64 { 0.15 }
-fn default_class2_flat_rate() -> f64 { 3.45 }
-fn default_class2_spt() -> f64 { 6725.0 }
+// Class 2 abolished from 6 April 2024 (NIC Act 2024); default to 0 for post-2024 years
+fn default_class2_flat_rate() -> f64 { 0.0 }
+fn default_class2_spt() -> f64 { 0.0 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UniversalCreditParams {

--- a/src/variables/benefits.rs
+++ b/src/variables/benefits.rs
@@ -238,7 +238,10 @@ fn calculate_universal_credit(
     let max_amount_annual = max_amount_monthly * 12.0;
 
     // Work allowance
-    let has_work_allowance = has_housing_costs || num_children > 0 || has_lcwra;
+    // UC Regs 2013 reg.22(1)(b)(ii): work allowance only available if claimant has
+    // responsibility for a child/qualifying young person or limited capability for work.
+    // Having housing costs does NOT confer entitlement — it only determines which rate applies.
+    let has_work_allowance = num_children > 0 || has_lcwra;
     let work_allowance_annual = if has_work_allowance {
         if has_housing_costs {
             uc.work_allowance_lower * 12.0

--- a/src/variables/income_tax.rs
+++ b/src/variables/income_tax.rs
@@ -792,7 +792,8 @@ mod parameter_impact_tests {
 
     #[test]
     fn param_ni_class2_flat_rate() {
-        let mut params = Parameters::for_year(2025).unwrap();
+        // Class 2 was abolished from April 2024; test against 2023/24 where it applied
+        let mut params = Parameters::for_year(2023).unwrap();
         let p = se_earner();
         let base = calc(&p, &params).national_insurance;
         params.national_insurance.class2_flat_rate_weekly += 1.0;
@@ -802,7 +803,8 @@ mod parameter_impact_tests {
 
     #[test]
     fn param_ni_class2_small_profits_threshold() {
-        let mut params = Parameters::for_year(2025).unwrap();
+        // Class 2 was abolished from April 2024; test against 2023/24 where it applied
+        let mut params = Parameters::for_year(2023).unwrap();
         // Person with SE income just above SPT
         let mut p = Person::default(); p.age = 35.0; p.self_employment_income = 7000.0;
         let base = calc(&p, &params).national_insurance;


### PR DESCRIPTION
## Summary
- Fix UC work allowance entitlement condition (UC Regs 2013 reg.22)
- Zero out Class 2 NI for 2024/25 and 2025/26 following abolition from April 2024
- Correct 2023/24 NI main rate to blended 11.5%

## Changes

**UC work allowance (`benefits.rs`)**
Removed `has_housing_costs` from the work allowance entitlement condition. Under UC Regs 2013 reg.22(1)(b)(ii), the work allowance is only available to claimants with responsibility for a child/qualifying young person or limited capability for work. Housing costs only determine which rate applies (higher vs lower), not whether the allowance applies at all. The previous logic incorrectly granted work allowances to renters with no children and no LCWRA.

**Class 2 NI abolition (`parameters/`, `mod.rs`)**
Class 2 NI contributions were abolished from 6 April 2024 (National Insurance Contributions Act 2024). Parameters for 2024/25 now explicitly set `class2_flat_rate_weekly: 0.0`; the erroneous `3.45` in 2025/26 is corrected. The serde default in `mod.rs` is changed from `3.45` to `0.0` so future year files are safe. `2023_24.yaml` gets an explicit `3.45` to preserve correct pre-abolition behaviour.

**2023/24 NI main rate (`parameters/2023_24.yaml`)**
Corrected from `0.12` to `0.115` — the blended rate for the fiscal year (12% × 9/12 + 10% × 3/12) following the NI (Reduction in Rates) Act 2023 cut from 6 January 2024. Using 12% overstated NI liability by ~4% for this year.

**Test updates (`income_tax.rs`)**
Updated two Class 2 parameter impact tests to use `for_year(2023)` since the parameter has no effect in post-2024 years.

## Test plan
- [x] All 106 tests pass locally
- [x] OBR validation test passes
- [x] Class 2 parameter impact tests updated to test correct year

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>