### PR TITLE
Add dataset= parameter to Simulation for SPI, LCFS, WAS

### DIFF
--- a/changelog.d/multi-dataset-simulation.added
+++ b/changelog.d/multi-dataset-simulation.added
@@ -1,0 +1,1 @@
+Add `dataset` parameter to `Simulation` to run simulations against SPI, LCFS, or WAS microdata. Pass `dataset="spi"`, `dataset="lcfs"`, or `dataset="was"` — data auto-downloads from GCS on first use. Also exports `ensure_dataset` and `DATASETS` from the package top-level.

--- a/interfaces/python/policyengine_uk_compiled/CLAUDE.md
+++ b/interfaces/python/policyengine_uk_compiled/CLAUDE.md
@@ -104,18 +104,28 @@ DELTA = 100  # £100 increment
 # Use "reform_net_income" column when policy is passed, "baseline_net_income" otherwise
 ```
 
-## Full FRS population runs
+## Full population runs (FRS, SPI, LCFS, WAS)
 
-If `POLICYENGINE_UK_DATA_TOKEN` is set, FRS data auto-downloads on demand (only the year needed, 3 files per year) to `~/.policyengine-uk-data/frs/`:
+If `POLICYENGINE_UK_DATA_TOKEN` is set, data auto-downloads on demand to `~/.policyengine-uk-data/<dataset>/`.
+
+Available datasets: `"frs"` (default), `"spi"`, `"lcfs"`, `"was"`.
 
 ```python
-# Auto-downloads frs/2025/ on first use (persons.csv, benunits.csv, households.csv)
+# FRS (default — no dataset= needed)
 sim = Simulation(year=2025)
 result = sim.run()
 
-# Download all years explicitly
+# SPI, LCFS, or WAS — pass dataset=
+sim = Simulation(year=2025, dataset="spi")
+result = sim.run()
+
+sim = Simulation(year=2025, dataset="lcfs")
+result = sim.run()
+
+# Download all datasets/years explicitly
 from policyengine_uk_compiled import download_all
-download_all()
+download_all()                        # all datasets
+download_all(datasets=("spi", "was")) # specific datasets
 ```
 
 Or with an explicit local path:

--- a/interfaces/python/policyengine_uk_compiled/__init__.py
+++ b/interfaces/python/policyengine_uk_compiled/__init__.py
@@ -60,7 +60,7 @@ from policyengine_uk_compiled.engine import (
     BENUNIT_DEFAULTS,
     HOUSEHOLD_DEFAULTS,
 )
-from policyengine_uk_compiled.data import download_all, ensure_year
+from policyengine_uk_compiled.data import download_all, ensure_year, ensure_dataset, DATASETS
 
 __all__ = [
     "Simulation",
@@ -69,6 +69,8 @@ __all__ = [
     "HOUSEHOLD_DEFAULTS",
     "download_all",
     "ensure_year",
+    "ensure_dataset",
+    "DATASETS",
     "SimulationConfig",
     "SimulationResult",
     "MicrodataResult",

--- a/interfaces/python/policyengine_uk_compiled/engine.py
+++ b/interfaces/python/policyengine_uk_compiled/engine.py
@@ -158,6 +158,7 @@ class Simulation:
         benunits=None,
         households=None,
         data_dir: Optional[Union[str, Path]] = None,
+        dataset: Optional[str] = None,
         # Legacy FRS interface
         clean_frs_base: Optional[str] = None,
         clean_frs: Optional[str] = None,
@@ -173,6 +174,7 @@ class Simulation:
         self._clean_frs_base = clean_frs_base
         self._clean_frs = clean_frs
         self._frs_raw = frs_raw
+        self._dataset = dataset
 
         if persons is not None and benunits is not None and households is not None:
             # DataFrame or CSV string mode
@@ -207,6 +209,10 @@ class Simulation:
             cmd += ["--data", self._clean_frs]
         elif self._frs_raw:
             cmd += ["--frs", self._frs_raw]
+        elif self._dataset is not None:
+            from policyengine_uk_compiled.data import ensure_dataset
+            data_path = ensure_dataset(self._dataset, self.year)
+            cmd += ["--data", data_path]
         else:
             # No data source specified — try auto-resolving FRS data
             from policyengine_uk_compiled.data import ensure_frs


### PR DESCRIPTION
## Summary
- Adds `dataset` kwarg to `Simulation.__init__` (`"frs"` default, plus `"spi"`, `"lcfs"`, `"was"`)
- Data auto-downloads from GCS on first use via existing `ensure_dataset()`
- Exports `ensure_dataset` and `DATASETS` from package top-level
- Updates CLAUDE.md so the chatbot knows about the new options

## Test plan
- [ ] `Simulation(year=2025, dataset="spi").run()` works with token set
- [ ] `Simulation(year=2025)` still defaults to FRS unchanged
- [ ] `from policyengine_uk_compiled import DATASETS` returns all four