### PR TITLE
Fix Modal deploy: source cargo env in build_package.sh

### DIFF
--- a/interfaces/python/build_package.sh
+++ b/interfaces/python/build_package.sh
@@ -3,6 +3,10 @@
 # Usage: ./interfaces/python/build_package.sh
 set -euo pipefail
 
+# Ensure cargo is on PATH (needed in non-interactive shells like Modal image builds)
+# shellcheck disable=SC1091
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR/../.."
 PKG_DIR="$SCRIPT_DIR/policyengine_uk_compiled"


### PR DESCRIPTION
The Modal image build runs `build_package.sh` which calls bare `cargo`, but `~/.cargo/env` isn't sourced in non-interactive shells. This adds a source line at the top of the script so `cargo` is found on PATH.

```
interfaces/python/build_package.sh: line 11: cargo: command not found
```