### PR TITLE
Fix publish workflow: checkout main to get bumped version

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Install Rust (container)
         if: matrix.container != ''
@@ -97,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Build-wheels was checking out the trigger commit (before the version bump), so wheels were tagged 0.6.2 instead of 0.7.0. Now checks out `main` which has the bump from the versioning job.