### PR TITLE
Add tenure_type to household microdata output

### DIFF
--- a/changelog.d/added/tenure-type-microdata.md
+++ b/changelog.d/added/tenure-type-microdata.md
@@ -1,0 +1,1 @@
+Add `tenure_type` column (numeric rf_code 0–5) to household-level microdata CSV output, enabling tenure-based filters in the microsim analysis layer.

--- a/src/data/clean.rs
+++ b/src/data/clean.rs
@@ -540,7 +540,7 @@ fn write_microdata_csv_households<W: std::io::Write>(
 
     wtr.write_record(&[
         "household_id", "weight", "region",
-        "rent_annual", "council_tax_annual",
+        "rent_annual", "council_tax_annual", "tenure_type",
         // ── Baseline outputs ──
         "baseline_net_income", "baseline_gross_income",
         "baseline_total_tax", "baseline_total_benefits",
@@ -561,6 +561,7 @@ fn write_microdata_csv_households<W: std::io::Write>(
             hh.region.name().to_string(),
             format!("{:.2}", hh.rent),
             format!("{:.2}", hh.council_tax),
+            (hh.tenure_type.to_rf_code() as i32).to_string(),
             // Baseline
             format!("{:.2}", bl.net_income),
             format!("{:.2}", bl.gross_income),


### PR DESCRIPTION
Adds `tenure_type` (as numeric rf_code 0–5) to the household-level microdata CSV output in `write_microdata_csv_households`. This column was already written in the clean input CSVs but missing from the microdata output, which the microsim analysis layer needs for tenure-based filters (renters, mortgage holders, owner-occupiers).

Codes: 0=OwnedOutright, 1=OwnedWithMortgage, 2=RentFromCouncil, 3=RentFromHA, 4=RentPrivately, 5=Other.

## Test plan

- [ ] `cargo check` passes
- [ ] Run `sim.run_microdata()` and verify `tenure_type` column appears in households DataFrame