### PR TITLE
Share simulation rate limits across workers

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""PolicyEngine UK API package."""

--- a/api/main.py
+++ b/api/main.py
@@ -5,9 +5,14 @@ import os
 import subprocess
 from typing import Any, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
+from api.security import (
+    enforce_simulation_rate_limit,
+    require_simulation_api_key,
+)
 
 app = FastAPI(title="PolicyEngine UK API")
 
@@ -147,7 +152,13 @@ async def get_years():
     return {"years": AVAILABLE_YEARS}
 
 
-@app.post("/api/simulate")
+@app.post(
+    "/api/simulate",
+    dependencies=[
+        Depends(require_simulation_api_key),
+        Depends(enforce_simulation_rate_limit),
+    ],
+)
 async def simulate(req: SimulateRequest):
     if req.year not in AVAILABLE_YEARS:
         raise HTTPException(400, detail=f"Year {req.year} not available")
@@ -158,7 +169,13 @@ async def simulate(req: SimulateRequest):
     return run_simulation(req.year, json.dumps(overlay))
 
 
-@app.post("/api/simulate-multi")
+@app.post(
+    "/api/simulate-multi",
+    dependencies=[
+        Depends(require_simulation_api_key),
+        Depends(enforce_simulation_rate_limit),
+    ],
+)
 async def simulate_multi(req: SimulateMultiYearRequest):
     """Run the same reform across multiple years. Returns {year: result}."""
     overlay = _extract_overlay(req)

--- a/api/modal_app.py
+++ b/api/modal_app.py
@@ -24,6 +24,10 @@ import modal
 # ---------------------------------------------------------------------------
 frs_volume = modal.Volume.from_name("policyengine-uk-frs", create_if_missing=True)
 FRS_MOUNT_PATH = "/data/frs_clean"
+rate_limit_volume = modal.Volume.from_name(
+    "policyengine-uk-rate-limit", create_if_missing=True
+)
+RATE_LIMIT_MOUNT_PATH = "/data/policyengine-uk-rate-limit"
 
 # ---------------------------------------------------------------------------
 # Image — Debian base, install Rust toolchain, clone repo, compile binary
@@ -63,11 +67,33 @@ def _make_fastapi_app():
     import json
     import os
     import subprocess
+    import tempfile
     from typing import Any, Optional
 
-    from fastapi import FastAPI, HTTPException
+    from fastapi import Depends, FastAPI, HTTPException
     from fastapi.middleware.cors import CORSMiddleware
     from pydantic import BaseModel
+
+    rate_limit_db_path = os.path.join(
+        tempfile.gettempdir(),
+        "policyengine-uk-rate-limit.sqlite",
+    )
+    if os.path.isdir(RATE_LIMIT_MOUNT_PATH) and os.access(
+        RATE_LIMIT_MOUNT_PATH, os.W_OK
+    ):
+        rate_limit_db_path = (
+            f"{RATE_LIMIT_MOUNT_PATH}/simulation-rate-limit.sqlite"
+        )
+
+    os.environ.setdefault(
+        "POLICYENGINE_UK_RATE_LIMIT_DB_PATH",
+        rate_limit_db_path,
+    )
+
+    from api.security import (
+        enforce_simulation_rate_limit,
+        require_simulation_api_key,
+    )
 
     RUST_BINARY = "policyengine-uk"
     CLEAN_FRS_DIR = FRS_MOUNT_PATH
@@ -191,7 +217,13 @@ def _make_fastapi_app():
     async def get_years():
         return {"years": AVAILABLE_YEARS}
 
-    @fastapi_app.post("/api/simulate")
+    @fastapi_app.post(
+        "/api/simulate",
+        dependencies=[
+            Depends(require_simulation_api_key),
+            Depends(enforce_simulation_rate_limit),
+        ],
+    )
     async def simulate(req: SimulateRequest):
         if req.year not in AVAILABLE_YEARS:
             raise HTTPException(400, detail=f"Year {req.year} not available")
@@ -200,7 +232,13 @@ def _make_fastapi_app():
             return baseline_cache.get(req.year, run_simulation(req.year))
         return run_simulation(req.year, json.dumps(overlay))
 
-    @fastapi_app.post("/api/simulate-multi")
+    @fastapi_app.post(
+        "/api/simulate-multi",
+        dependencies=[
+            Depends(require_simulation_api_key),
+            Depends(enforce_simulation_rate_limit),
+        ],
+    )
     async def simulate_multi(req: SimulateMultiYearRequest):
         overlay = _extract_overlay(req)
         results = {}
@@ -227,7 +265,10 @@ def _make_fastapi_app():
 
 
 @app.function(
-    volumes={FRS_MOUNT_PATH: frs_volume},
+    volumes={
+        FRS_MOUNT_PATH: frs_volume,
+        RATE_LIMIT_MOUNT_PATH: rate_limit_volume,
+    },
     # Startup caches all 7 year baselines — give it enough RAM
     memory=4096,
     cpu=4,

--- a/api/security.py
+++ b/api/security.py
@@ -1,0 +1,161 @@
+"""Shared security helpers for the UK simulation API."""
+
+import os
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Header, HTTPException, Request, status
+
+_LOCAL_CLIENT_HOSTS = {"127.0.0.1", "::1", "localhost", "testclient"}
+_RATE_LIMIT_DB_ENV = "POLICYENGINE_UK_RATE_LIMIT_DB_PATH"
+
+
+def _default_rate_limit_db_path() -> str:
+    return str(Path(tempfile.gettempdir()) / "policyengine-uk-rate-limit.sqlite")
+
+
+class RateLimiter:
+    """SQLite-backed sliding-window limiter keyed by client host."""
+
+    def __init__(
+        self,
+        limit: int,
+        window_seconds: int,
+        db_path: str | None = None,
+    ):
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self.db_path = db_path or os.getenv(
+            _RATE_LIMIT_DB_ENV, _default_rate_limit_db_path()
+        )
+        self._initialize_storage()
+
+    def _initialize_storage(self) -> None:
+        db_dir = os.path.dirname(self.db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+
+        with sqlite3.connect(self.db_path, timeout=5.0) as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS simulation_rate_limit_events (
+                    client_host TEXT NOT NULL,
+                    requested_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_simulation_rate_limit_events
+                ON simulation_rate_limit_events (client_host, requested_at)
+                """
+            )
+
+    def check(self, request: Request, now: float | None = None) -> None:
+        client_host = getattr(getattr(request, "client", None), "host", None)
+        if client_host in _LOCAL_CLIENT_HOSTS:
+            return
+
+        now = time.time() if now is None else now
+        cutoff = now - self.window_seconds
+        client_key = client_host or "unknown"
+
+        with sqlite3.connect(self.db_path, timeout=5.0, isolation_level=None) as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                DELETE FROM simulation_rate_limit_events
+                WHERE client_host = ? AND requested_at <= ?
+                """,
+                (client_key, cutoff),
+            )
+            current_count = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM simulation_rate_limit_events
+                WHERE client_host = ?
+                """,
+                (client_key,),
+            ).fetchone()[0]
+            if current_count >= self.limit:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Rate limit exceeded for simulation endpoints",
+                )
+            conn.execute(
+                """
+                INSERT INTO simulation_rate_limit_events (client_host, requested_at)
+                VALUES (?, ?)
+                """,
+                (client_key, now),
+            )
+
+
+SIMULATION_RATE_LIMITER = RateLimiter(
+    limit=int(os.getenv("POLICYENGINE_UK_RATE_LIMIT", "10")),
+    window_seconds=int(os.getenv("POLICYENGINE_UK_RATE_LIMIT_WINDOW_SECONDS", "60")),
+    db_path=os.getenv(_RATE_LIMIT_DB_ENV, _default_rate_limit_db_path()),
+)
+
+
+_SIMULATION_RATE_LIMITER_CONFIG = (
+    SIMULATION_RATE_LIMITER.limit,
+    SIMULATION_RATE_LIMITER.window_seconds,
+    SIMULATION_RATE_LIMITER.db_path,
+)
+
+
+def get_simulation_rate_limiter() -> RateLimiter:
+    """Return the configured shared limiter, rebuilding it if config changed."""
+
+    global SIMULATION_RATE_LIMITER, _SIMULATION_RATE_LIMITER_CONFIG
+
+    config = (
+        int(os.getenv("POLICYENGINE_UK_RATE_LIMIT", "10")),
+        int(os.getenv("POLICYENGINE_UK_RATE_LIMIT_WINDOW_SECONDS", "60")),
+        os.getenv(_RATE_LIMIT_DB_ENV, _default_rate_limit_db_path()),
+    )
+    if _SIMULATION_RATE_LIMITER_CONFIG != config:
+        SIMULATION_RATE_LIMITER = RateLimiter(
+            limit=config[0],
+            window_seconds=config[1],
+            db_path=config[2],
+        )
+        _SIMULATION_RATE_LIMITER_CONFIG = config
+
+    return SIMULATION_RATE_LIMITER
+
+
+def require_simulation_api_key(
+    request: Request,
+    x_policyengine_api_key: Annotated[
+        str | None, Header(alias="X-PolicyEngine-Api-Key")
+    ] = None,
+) -> None:
+    """Require the shared API key for non-local simulation requests."""
+
+    client_host = getattr(getattr(request, "client", None), "host", None)
+    if client_host in _LOCAL_CLIENT_HOSTS:
+        return
+
+    expected_key = os.getenv("POLICYENGINE_UK_API_KEY", "").strip()
+    if expected_key and x_policyengine_api_key == expected_key:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Simulation API key required",
+    )
+
+
+def enforce_simulation_rate_limit(request: Request) -> None:
+    """Apply the shared sqlite-backed limiter to simulation endpoints."""
+
+    get_simulation_rate_limiter().check(request)

--- a/api/tests/test_security.py
+++ b/api/tests/test_security.py
@@ -1,0 +1,147 @@
+import pytest
+from fastapi import HTTPException, Request
+
+from api.main import app
+from api.modal_app import _make_fastapi_app
+from api import security
+from api.security import (
+    RateLimiter,
+    require_simulation_api_key,
+)
+
+
+def _make_request(
+    path: str,
+    client_host: str = "203.0.113.10",
+    headers: dict[str, str] | None = None,
+) -> Request:
+    raw_headers = [(b"host", b"api.policyengine.org")]
+    for key, value in (headers or {}).items():
+        raw_headers.append((key.lower().encode("ascii"), value.encode("ascii")))
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "https",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": (client_host, 443),
+        "server": ("api.policyengine.org", 443),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def test_simulation_guard_blocks_external_requests_without_key(monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_UK_API_KEY", "secret-key")
+    request = _make_request("/api/simulate")
+
+    with pytest.raises(HTTPException, match="Simulation API key required") as exc_info:
+        require_simulation_api_key(request)
+
+    assert exc_info.value.status_code == 401
+
+
+def test_simulation_guard_allows_external_requests_with_key(monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_UK_API_KEY", "secret-key")
+    request = _make_request(
+        "/api/simulate",
+        headers={"X-PolicyEngine-Api-Key": "secret-key"},
+    )
+
+    assert (
+        require_simulation_api_key(
+            request, x_policyengine_api_key="secret-key"
+        )
+        is None
+    )
+
+
+def test_simulation_guard_allows_local_requests_without_key(monkeypatch):
+    monkeypatch.setenv("POLICYENGINE_UK_API_KEY", "secret-key")
+    request = _make_request("/api/simulate", client_host="127.0.0.1")
+
+    assert require_simulation_api_key(request) is None
+
+
+def test_rate_limiter_blocks_requests_over_window(tmp_path):
+    limiter = RateLimiter(
+        limit=2,
+        window_seconds=60,
+        db_path=str(tmp_path / "rate-limit.sqlite"),
+    )
+    request = _make_request("/api/simulate", headers={"X-PolicyEngine-Api-Key": "secret-key"})
+
+    limiter.check(request, now=100)
+    limiter.check(request, now=120)
+
+    with pytest.raises(HTTPException, match="Rate limit exceeded") as exc_info:
+        limiter.check(request, now=130)
+
+    assert exc_info.value.status_code == 429
+
+
+def test_rate_limiter_expires_old_requests(tmp_path):
+    limiter = RateLimiter(
+        limit=2,
+        window_seconds=60,
+        db_path=str(tmp_path / "rate-limit.sqlite"),
+    )
+    request = _make_request("/api/simulate", headers={"X-PolicyEngine-Api-Key": "secret-key"})
+
+    limiter.check(request, now=100)
+    limiter.check(request, now=120)
+    limiter.check(request, now=161)
+
+
+def test_rate_limiter_shares_state_across_instances(tmp_path):
+    db_path = tmp_path / "rate-limit.sqlite"
+    request = _make_request("/api/simulate", headers={"X-PolicyEngine-Api-Key": "secret-key"})
+
+    first = RateLimiter(limit=2, window_seconds=60, db_path=str(db_path))
+    second = RateLimiter(limit=2, window_seconds=60, db_path=str(db_path))
+
+    first.check(request, now=100)
+    second.check(request, now=120)
+
+    third = RateLimiter(limit=2, window_seconds=60, db_path=str(db_path))
+    with pytest.raises(HTTPException, match="Rate limit exceeded") as exc_info:
+        third.check(request, now=130)
+
+    assert exc_info.value.status_code == 429
+
+
+def test_rate_limiter_rebuilds_when_env_db_path_changes(monkeypatch, tmp_path):
+    new_db_path = tmp_path / "shared-rate-limit.sqlite"
+    monkeypatch.setenv("POLICYENGINE_UK_RATE_LIMIT_DB_PATH", str(new_db_path))
+
+    limiter = security.get_simulation_rate_limiter()
+
+    assert limiter.db_path == str(new_db_path)
+
+
+@pytest.mark.parametrize("fastapi_app", [app, _make_fastapi_app()], ids=["main", "modal"])
+def test_expensive_post_routes_are_protected(fastapi_app):
+    protected_paths = {"/api/simulate", "/api/simulate-multi"}
+
+    route_map = {
+        route.path: route
+        for route in fastapi_app.routes
+        if getattr(route, "methods", None) and "POST" in route.methods
+    }
+
+    for path in protected_paths:
+        route = route_map[path]
+        dependency_names = {
+            getattr(dependency.call, "__name__", "")
+            for dependency in route.dependant.dependencies
+        }
+        assert "require_simulation_api_key" in dependency_names
+        assert "enforce_simulation_rate_limit" in dependency_names


### PR DESCRIPTION
## Summary
- move the UK simulation limiter from process-local memory into a sqlite-backed sliding window store
- configure the Modal deployment to mount shared limiter state so multiple workers can enforce the same budget
- add regression coverage for shared-state limiting, env-configured db paths, and the protected simulation routes

## Testing
- POLICYENGINE_UK_RATE_LIMIT_DB_PATH= PYTHONPATH=.. uv run pytest tests/test_security.py -q