### PR TITLE
Add structural comparison helpers for chat consumers

### DIFF
--- a/changelog.d/added/chat-structural-hooks-hbai-fields.md
+++ b/changelog.d/added/chat-structural-hooks-hbai-fields.md
@@ -1,0 +1,1 @@
+Export separate `baseline_hbai_incomes` and `reform_hbai_incomes` in simulation results, and add shared helpers for combining baseline and structurally modified microdata into one clean comparison view for chatbot consumers using `StructuralReform`.

--- a/interfaces/python/policyengine_uk_compiled/__init__.py
+++ b/interfaces/python/policyengine_uk_compiled/__init__.py
@@ -67,12 +67,14 @@ from policyengine_uk_compiled.engine import (
     BENUNIT_DEFAULTS,
     HOUSEHOLD_DEFAULTS,
 )
-from policyengine_uk_compiled.structural import StructuralReform
+from policyengine_uk_compiled.structural import StructuralReform, aggregate_microdata, combine_microdata
 from policyengine_uk_compiled.data import download_all, ensure_year, ensure_dataset, DATASETS, capabilities
 
 __all__ = [
     "Simulation",
     "StructuralReform",
+    "aggregate_microdata",
+    "combine_microdata",
     "PERSON_DEFAULTS",
     "BENUNIT_DEFAULTS",
     "HOUSEHOLD_DEFAULTS",

--- a/interfaces/python/policyengine_uk_compiled/engine.py
+++ b/interfaces/python/policyengine_uk_compiled/engine.py
@@ -290,7 +290,12 @@ def _aggregate_persons_only(records: list[dict], year: int) -> SimulationResult:
             avg_gain=round(total_gain / winners_w) if winners_w > 0 else 0.0,
             avg_loss=round(total_loss / losers_w) if losers_w > 0 else 0.0,
         ),
-        hbai_incomes=HbaiIncomes(
+        baseline_hbai_incomes=HbaiIncomes(
+            mean_equiv_bhc=0.0, mean_equiv_ahc=0.0,
+            mean_bhc=0.0, mean_ahc=0.0,
+            median_equiv_bhc=0.0, median_equiv_ahc=0.0,
+        ),
+        reform_hbai_incomes=HbaiIncomes(
             mean_equiv_bhc=0.0, mean_equiv_ahc=0.0,
             mean_bhc=0.0, mean_ahc=0.0,
             median_equiv_bhc=0.0, median_equiv_ahc=0.0,

--- a/interfaces/python/policyengine_uk_compiled/models.py
+++ b/interfaces/python/policyengine_uk_compiled/models.py
@@ -371,7 +371,8 @@ class SimulationResult(BaseModel):
     caseloads: Caseloads
     decile_impacts: list[DecileImpact]
     winners_losers: WinnersLosers
-    hbai_incomes: HbaiIncomes
+    baseline_hbai_incomes: HbaiIncomes
+    reform_hbai_incomes: HbaiIncomes
     baseline_poverty: PovertyHeadcounts
     reform_poverty: PovertyHeadcounts
     cpi_index: float

--- a/interfaces/python/policyengine_uk_compiled/structural.py
+++ b/interfaces/python/policyengine_uk_compiled/structural.py
@@ -100,11 +100,57 @@ def aggregate_microdata(
     wealth-tax reforms, which are unlikely to be applied as post-hooks.
     """
     import numpy as np
+    import pandas as pd
     from policyengine_uk_compiled.models import (
         BudgetaryImpact, IncomeBreakdown, ProgramBreakdown, Caseloads,
         DecileImpact, WinnersLosers, SimulationResult,
         HbaiIncomes, PovertyHeadcounts,
     )
+
+    def cpi_index_for_year(year: int) -> float:
+        table = {
+            1994: 55.5, 1995: 56.9, 1996: 58.3, 1997: 59.5,
+            1998: 61.0, 1999: 61.7, 2000: 62.7, 2001: 63.6,
+            2002: 64.7, 2003: 65.7, 2004: 66.8, 2005: 68.1,
+            2006: 69.8, 2007: 71.5, 2008: 74.1, 2009: 75.5,
+            2010: 78.0, 2011: 81.5, 2012: 83.6, 2013: 85.6,
+            2014: 86.5, 2015: 86.5, 2016: 87.5, 2017: 89.9,
+            2018: 92.1, 2019: 93.8, 2020: 94.6, 2021: 97.5,
+            2022: 107.3, 2023: 113.4, 2024: 116.1, 2025: 120.1,
+            2026: 122.5, 2027: 124.9, 2028: 127.4, 2029: 130.0,
+        }
+        base = 120.1
+        return table.get(year, base) / base * 100.0
+
+    def weighted_median(values: np.ndarray, weights: np.ndarray) -> float:
+        if len(values) == 0:
+            return 0.0
+        order = np.argsort(values)
+        values = values[order]
+        weights = weights[order]
+        cutoff = weights.sum() / 2.0
+        return float(values[np.searchsorted(np.cumsum(weights), cutoff, side="left")])
+
+    person_counts = persons.groupby("household_id").size() if "household_id" in persons.columns else pd.Series(dtype=float)
+
+    def hbai_for(prefix: str) -> HbaiIncomes:
+        hh = households.copy()
+        hh["person_count"] = hh["household_id"].map(person_counts).fillna(0.0)
+        person_weights = hh["weight"].values * hh["person_count"].values
+        equiv_ahc_col = f"{prefix}_equivalised_net_income_ahc"
+        net_ahc_col = f"{prefix}_net_income_ahc"
+        if equiv_ahc_col not in hh.columns:
+            hh[equiv_ahc_col] = hh[f"{prefix}_equivalised_net_income"]
+        if net_ahc_col not in hh.columns:
+            hh[net_ahc_col] = hh[f"{prefix}_net_income"]
+        return HbaiIncomes(
+            mean_equiv_bhc=float((hh["weight"] * hh[f"{prefix}_equivalised_net_income"]).sum() / hh["weight"].sum()) if len(hh) else 0.0,
+            mean_equiv_ahc=float((hh["weight"] * hh[equiv_ahc_col]).sum() / hh["weight"].sum()) if len(hh) else 0.0,
+            mean_bhc=float((hh["weight"] * hh[f"{prefix}_net_income"]).sum() / hh["weight"].sum()) if len(hh) else 0.0,
+            mean_ahc=float((hh["weight"] * hh[net_ahc_col]).sum() / hh["weight"].sum()) if len(hh) else 0.0,
+            median_equiv_bhc=weighted_median(hh[f"{prefix}_equivalised_net_income"].values, person_weights),
+            median_equiv_ahc=weighted_median(hh[equiv_ahc_col].values, person_weights),
+        )
 
     w = households["weight"].values
 
@@ -281,6 +327,63 @@ def aggregate_microdata(
     )
 
     fiscal_year = f"{year}/{(year + 1) % 100:02d}"
+    baseline_hbai_incomes = hbai_for("baseline")
+    reform_hbai_incomes = hbai_for("reform")
+
+    rel_line_bhc = 0.60 * baseline_hbai_incomes.median_equiv_bhc
+    rel_line_ahc = 0.60 * baseline_hbai_incomes.median_equiv_ahc
+    cpi_index = cpi_index_for_year(year)
+    abs_line_bhc = 14_400.0 * (cpi_index / 100.0)
+    abs_line_ahc = 11_600.0 * (cpi_index / 100.0)
+
+    hh_for_poverty = households.copy()
+    for prefix in ("baseline", "reform"):
+        equiv_ahc_col = f"{prefix}_equivalised_net_income_ahc"
+        if equiv_ahc_col not in hh_for_poverty.columns:
+            hh_for_poverty[equiv_ahc_col] = hh_for_poverty[f"{prefix}_equivalised_net_income"]
+
+    pw = persons.merge(
+        hh_for_poverty[[
+            "household_id", "weight",
+            "baseline_equivalised_net_income", "baseline_equivalised_net_income_ahc",
+            "reform_equivalised_net_income", "reform_equivalised_net_income_ahc",
+        ]],
+        on="household_id",
+        how="left",
+    )
+
+    def poverty_for(prefix: str) -> PovertyHeadcounts:
+        eq_bhc = pw[f"{prefix}_equivalised_net_income"]
+        eq_ahc = pw[f"{prefix}_equivalised_net_income_ahc"]
+        weights = pw["weight"].fillna(1.0)
+        ages = pw["age"]
+
+        child = ages < 16.0
+        working = (ages >= 16.0) & (ages < 66.0)
+        pensioner = ages >= 66.0
+
+        def pct(mask, denom_mask):
+            denom = float(weights[denom_mask].sum())
+            num = float(weights[mask & denom_mask].sum())
+            return round(100.0 * num / denom, 1) if denom > 0 else 0.0
+
+        return PovertyHeadcounts(
+            relative_bhc_children=pct(eq_bhc < rel_line_bhc, child),
+            relative_bhc_working_age=pct(eq_bhc < rel_line_bhc, working),
+            relative_bhc_pensioners=pct(eq_bhc < rel_line_bhc, pensioner),
+            relative_ahc_children=pct(eq_ahc < rel_line_ahc, child),
+            relative_ahc_working_age=pct(eq_ahc < rel_line_ahc, working),
+            relative_ahc_pensioners=pct(eq_ahc < rel_line_ahc, pensioner),
+            absolute_bhc_children=pct(eq_bhc < abs_line_bhc, child),
+            absolute_bhc_working_age=pct(eq_bhc < abs_line_bhc, working),
+            absolute_bhc_pensioners=pct(eq_bhc < abs_line_bhc, pensioner),
+            absolute_ahc_children=pct(eq_ahc < abs_line_ahc, child),
+            absolute_ahc_working_age=pct(eq_ahc < abs_line_ahc, working),
+            absolute_ahc_pensioners=pct(eq_ahc < abs_line_ahc, pensioner),
+        )
+
+    baseline_poverty = poverty_for("baseline")
+    reform_poverty = poverty_for("reform")
 
     return SimulationResult(
         fiscal_year=fiscal_year,
@@ -298,22 +401,40 @@ def aggregate_microdata(
         caseloads=caseloads,
         decile_impacts=decile_impacts,
         winners_losers=winners_losers,
-        hbai_incomes=HbaiIncomes(
-            mean_equiv_bhc=0.0, mean_equiv_ahc=0.0,
-            mean_bhc=0.0, mean_ahc=0.0,
-            median_equiv_bhc=0.0, median_equiv_ahc=0.0,
-        ),
-        baseline_poverty=PovertyHeadcounts(
-            relative_bhc_children=0.0, relative_bhc_working_age=0.0, relative_bhc_pensioners=0.0,
-            relative_ahc_children=0.0, relative_ahc_working_age=0.0, relative_ahc_pensioners=0.0,
-            absolute_bhc_children=0.0, absolute_bhc_working_age=0.0, absolute_bhc_pensioners=0.0,
-            absolute_ahc_children=0.0, absolute_ahc_working_age=0.0, absolute_ahc_pensioners=0.0,
-        ),
-        reform_poverty=PovertyHeadcounts(
-            relative_bhc_children=0.0, relative_bhc_working_age=0.0, relative_bhc_pensioners=0.0,
-            relative_ahc_children=0.0, relative_ahc_working_age=0.0, relative_ahc_pensioners=0.0,
-            absolute_bhc_children=0.0, absolute_bhc_working_age=0.0, absolute_bhc_pensioners=0.0,
-            absolute_ahc_children=0.0, absolute_ahc_working_age=0.0, absolute_ahc_pensioners=0.0,
-        ),
-        cpi_index=100.0,
+        baseline_hbai_incomes=baseline_hbai_incomes,
+        reform_hbai_incomes=reform_hbai_incomes,
+        baseline_poverty=baseline_poverty,
+        reform_poverty=reform_poverty,
+        cpi_index=cpi_index,
+    )
+
+
+def combine_microdata(
+    baseline: "MicrodataResult",  # noqa: F821
+    reform: "MicrodataResult",  # noqa: F821
+) -> "MicrodataResult":  # noqa: F821
+    """Combine baseline-run and reform-run microdata into one comparison view.
+
+    Baseline columns come from the original run. Reform columns come from the
+    structurally/policy-modified run. Unprefixed columns come from the reform run.
+    """
+    from policyengine_uk_compiled.models import MicrodataResult
+
+    def combine_entity(baseline_df, reform_df, id_col: str):
+        if reform_df is None or len(reform_df) == 0:
+            return reform_df
+        combined = reform_df.copy()
+        if baseline_df is None or len(baseline_df) == 0 or id_col not in baseline_df.columns or id_col not in reform_df.columns:
+            return combined
+        baseline_prefixed = [c for c in baseline_df.columns if c.startswith("baseline_")]
+        if not baseline_prefixed:
+            return combined
+        baseline_slice = baseline_df[[id_col] + baseline_prefixed].copy()
+        combined = combined.drop(columns=[c for c in baseline_prefixed if c in combined.columns])
+        return combined.merge(baseline_slice, on=id_col, how="left")
+
+    return MicrodataResult(
+        persons=combine_entity(baseline.persons, reform.persons, "person_id"),
+        benunits=combine_entity(baseline.benunits, reform.benunits, "benunit_id"),
+        households=combine_entity(baseline.households, reform.households, "household_id"),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine-uk-compiled"
-version = "0.18.0"
+version = "0.19.0"
 description = "Compiled UK tax-benefit microsimulation engine (Rust binary with Python interface)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,11 +216,11 @@ struct JsonOutput {
 }
 
 /// CPI index by fiscal year (2025/26 = 100).
-/// Sources: ONS CPI annual average (historical), OBR EFO March 2026 (forecast).
-/// Each value is the annual average CPI index for that fiscal year.
+/// Sources: ONS CPI annual average (historical), OBR EFO March 2026 table 1.7 (forecast).
+/// Each value is the annual average CPI index aligned to the fiscal year label.
 fn cpi_index_for_year(year: u32) -> f64 {
     // ONS CPI Index (2015=100) annual averages, mapped to fiscal years.
-    // Historical values from ONS series D7BT; forecasts from OBR EFO March 2026.
+    // Historical values from ONS series D7BT; forecasts from OBR EFO March 2026 table 1.7.
     // All rebased to 2025/26 = 100.
     let table: &[(u32, f64)] = &[
         (1994, 55.5), (1995, 56.9), (1996, 58.3), (1997, 59.5),
@@ -230,12 +230,12 @@ fn cpi_index_for_year(year: u32) -> f64 {
         (2010, 78.0), (2011, 81.5), (2012, 83.6), (2013, 85.6),
         (2014, 86.5), (2015, 86.5), (2016, 87.5), (2017, 89.9),
         (2018, 92.1), (2019, 93.8), (2020, 94.6), (2021, 97.5),
-        (2022, 107.3), (2023, 113.4), (2024, 116.1),
-        (2025, 120.1), (2026, 122.5), (2027, 124.9),
-        (2028, 127.4), (2029, 130.0),
+        (2022, 107.3), (2023, 113.4), (2024, 133.853167),
+        (2025, 138.368083), (2026, 141.552006), (2027, 144.338518),
+        (2028, 147.191323), (2029, 150.164842),
     ];
     // Rebase so 2025/26 = 100
-    let base = 120.1;
+    let base = 138.368083;
     table.iter()
         .find(|(y, _)| *y == year)
         .map(|(_, v)| v / base * 100.0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ struct Cli {
     persons_only: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct HbaiIncomes {
     /// Weighted mean equivalised net income BHC
     mean_equiv_bhc: f64,
@@ -207,7 +207,8 @@ struct JsonOutput {
     caseloads: Caseloads,
     decile_impacts: Vec<DecileImpact>,
     winners_losers: WinnersLosers,
-    hbai_incomes: HbaiIncomes,
+    baseline_hbai_incomes: HbaiIncomes,
+    reform_hbai_incomes: HbaiIncomes,
     baseline_poverty: PovertyHeadcounts,
     reform_poverty: PovertyHeadcounts,
     /// CPI index (2025/26 = 100) for deflating nominal values to real terms.
@@ -892,10 +893,14 @@ fn main() -> anyhow::Result<()> {
     // ── HBAI income aggregates ────────────────────────────────────────────────
     let total_weight: f64 = households.iter().map(|h| h.weight).sum();
 
-    let hbai_incomes = {
+    let compute_hbai_incomes = |results: &crate::engine::simulation::SimulationResults| -> HbaiIncomes {
+        // Weighted median over individuals: each person carries the household's weight.
+        let total_person_weight: f64 = households.iter()
+            .map(|h| h.weight * (h.person_ids.len() as f64))
+            .sum();
         let weighted_median = |vals: &mut Vec<(f64, f64)>| -> f64 {
             vals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-            let half = total_weight / 2.0;
+            let half = total_person_weight / 2.0;
             let mut cum = 0.0;
             for &(v, w) in vals.iter() {
                 cum += w;
@@ -905,36 +910,44 @@ fn main() -> anyhow::Result<()> {
         };
 
         let mut equiv_bhc: Vec<(f64, f64)> = households.iter()
-            .map(|h| (baseline.household_results[h.id].equivalised_net_income, h.weight))
+            .map(|h| {
+                let w = h.weight * (h.person_ids.len() as f64);
+                (results.household_results[h.id].equivalised_net_income, w)
+            })
             .collect();
         let mut equiv_ahc: Vec<(f64, f64)> = households.iter()
-            .map(|h| (baseline.household_results[h.id].equivalised_net_income_ahc, h.weight))
+            .map(|h| {
+                let w = h.weight * (h.person_ids.len() as f64);
+                (results.household_results[h.id].equivalised_net_income_ahc, w)
+            })
             .collect();
 
         let median_equiv_bhc = weighted_median(&mut equiv_bhc);
         let median_equiv_ahc = weighted_median(&mut equiv_ahc);
 
         let mean_equiv_bhc = households.iter()
-            .map(|h| h.weight * baseline.household_results[h.id].equivalised_net_income)
+            .map(|h| h.weight * results.household_results[h.id].equivalised_net_income)
             .sum::<f64>() / total_weight;
         let mean_equiv_ahc = households.iter()
-            .map(|h| h.weight * baseline.household_results[h.id].equivalised_net_income_ahc)
+            .map(|h| h.weight * results.household_results[h.id].equivalised_net_income_ahc)
             .sum::<f64>() / total_weight;
         let mean_bhc = households.iter()
-            .map(|h| h.weight * baseline.household_results[h.id].net_income)
+            .map(|h| h.weight * results.household_results[h.id].net_income)
             .sum::<f64>() / total_weight;
         let mean_ahc = households.iter()
-            .map(|h| h.weight * baseline.household_results[h.id].net_income_ahc)
+            .map(|h| h.weight * results.household_results[h.id].net_income_ahc)
             .sum::<f64>() / total_weight;
 
         HbaiIncomes { mean_equiv_bhc, mean_equiv_ahc, mean_bhc, mean_ahc,
                       median_equiv_bhc, median_equiv_ahc }
     };
+    let baseline_hbai_incomes = compute_hbai_incomes(&baseline);
+    let reform_hbai_incomes = compute_hbai_incomes(&reformed);
 
     // ── Poverty headcounts ────────────────────────────────────────────────────
     // Relative lines: 60% of baseline weighted median equivalised income
-    let rel_line_bhc = 0.60 * hbai_incomes.median_equiv_bhc;
-    let rel_line_ahc = 0.60 * hbai_incomes.median_equiv_ahc;
+    let rel_line_bhc = 0.60 * baseline_hbai_incomes.median_equiv_bhc;
+    let rel_line_ahc = 0.60 * baseline_hbai_incomes.median_equiv_ahc;
     // Absolute lines: 60% of median in 2010/11 (ONS HBAI reference, uprated by CPI to nominal)
     // 2010/11 median equivalised BHC ~£14,400/yr; AHC ~£11,600/yr (2010/11 prices)
     // Uprate to simulation year using CPI index
@@ -1023,7 +1036,8 @@ fn main() -> anyhow::Result<()> {
             caseloads,
             decile_impacts,
             winners_losers,
-            hbai_incomes,
+            baseline_hbai_incomes,
+            reform_hbai_incomes,
             baseline_poverty,
             reform_poverty,
             cpi_index: cpi_index_for_year(cli.year),
@@ -1085,6 +1099,51 @@ fn main() -> anyhow::Result<()> {
         "▼".bright_red(), winners_losers.losers_pct, winners_losers.avg_loss);
     println!("    {} {:.1}% unchanged",
         "●".dimmed(), winners_losers.unchanged_pct);
+
+    // HBAI incomes (means/medians)
+    println!("\n  {}", "HBAI INCOMES".bright_white().bold().underline());
+    println!();
+    let mut hbai_table = Table::new();
+    hbai_table.load_preset(presets::UTF8_FULL);
+    hbai_table.set_content_arrangement(ContentArrangement::Dynamic);
+    hbai_table.set_header(vec!["Metric", "Value"]);
+    hbai_table.add_row(vec!["Median equivalised BHC".to_string(), format!("£{:.0}", baseline_hbai_incomes.median_equiv_bhc)]);
+    hbai_table.add_row(vec!["Median equivalised AHC".to_string(), format!("£{:.0}", baseline_hbai_incomes.median_equiv_ahc)]);
+    hbai_table.add_row(vec!["Mean equivalised BHC".to_string(), format!("£{:.0}", baseline_hbai_incomes.mean_equiv_bhc)]);
+    hbai_table.add_row(vec!["Mean equivalised AHC".to_string(), format!("£{:.0}", baseline_hbai_incomes.mean_equiv_ahc)]);
+    hbai_table.add_row(vec!["Mean BHC (unequivalised)".to_string(), format!("£{:.0}", baseline_hbai_incomes.mean_bhc)]);
+    hbai_table.add_row(vec!["Mean AHC (unequivalised)".to_string(), format!("£{:.0}", baseline_hbai_incomes.mean_ahc)]);
+    println!("{hbai_table}");
+
+    // Poverty headcounts
+    println!("\n  {}", "POVERTY HEADCOUNTS".bright_white().bold().underline());
+    println!();
+    let mut pov_table = Table::new();
+    pov_table.load_preset(presets::UTF8_FULL);
+    pov_table.set_content_arrangement(ContentArrangement::Dynamic);
+    pov_table.set_header(vec!["Group", "Relative BHC", "Relative AHC", "Absolute BHC", "Absolute AHC"]);
+    pov_table.add_row(vec![
+        "Children".to_string(),
+        format!("{:.1}%", baseline_poverty.relative_bhc_children),
+        format!("{:.1}%", baseline_poverty.relative_ahc_children),
+        format!("{:.1}%", baseline_poverty.absolute_bhc_children),
+        format!("{:.1}%", baseline_poverty.absolute_ahc_children),
+    ]);
+    pov_table.add_row(vec![
+        "Working-age".to_string(),
+        format!("{:.1}%", baseline_poverty.relative_bhc_working_age),
+        format!("{:.1}%", baseline_poverty.relative_ahc_working_age),
+        format!("{:.1}%", baseline_poverty.absolute_bhc_working_age),
+        format!("{:.1}%", baseline_poverty.absolute_ahc_working_age),
+    ]);
+    pov_table.add_row(vec![
+        "Pensioners".to_string(),
+        format!("{:.1}%", baseline_poverty.relative_bhc_pensioners),
+        format!("{:.1}%", baseline_poverty.relative_ahc_pensioners),
+        format!("{:.1}%", baseline_poverty.absolute_bhc_pensioners),
+        format!("{:.1}%", baseline_poverty.absolute_ahc_pensioners),
+    ]);
+    println!("{pov_table}");
 
     println!();
     println!("{}", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".bright_blue());


### PR DESCRIPTION
## Summary
- add explicit baseline and reform HBAI income fields to simulation results
- add shared Python helpers to combine baseline-run and structural-run microdata into one comparison view
- compute HBAI and poverty metrics in the structural aggregation path so chat consumers can compare structural scenarios against the true baseline

## Testing
- source ~/.cargo/env && cargo build
- PYTHONDONTWRITEBYTECODE=1 python - <<'PY'
import sys
sys.path.insert(0, "/Users/nikhilwoodruff/policyengine/policyengine-uk-rust/interfaces/python")
from policyengine_uk_compiled import Simulation, StructuralReform, combine_microdata, aggregate_microdata
persons, benunits, households = Simulation.single_person(employment_income=30000)
sim = Simulation(year=2025, persons=persons, benunits=benunits, households=households)
def hook(year, persons, benunits, households):
    persons = persons.copy()
    persons["employment_income"] = persons["employment_income"] * 0.9
    return persons, benunits, households
baseline_micro = sim.run_microdata()
scenario_micro = sim.run_microdata(structural=StructuralReform(pre=hook))
combined = combine_microdata(baseline_micro, scenario_micro)
result = aggregate_microdata(combined.persons, combined.benunits, combined.households, 2025)
print(round(result.baseline_hbai_incomes.mean_bhc, 2), round(result.reform_hbai_incomes.mean_bhc, 2))
PY